### PR TITLE
Update pronk to new http-enumerator 0.7 API

### DIFF
--- a/lib/Network/HTTP/LoadTest/Types.hs
+++ b/lib/Network/HTTP/LoadTest/Types.hs
@@ -37,22 +37,22 @@ newtype Req = Req {
     } deriving (Typeable)
 
 instance Show Req where
-    show (Req Request{..}) = concat [http, B.unpack host, portie, B.unpack path,
-                                     B.unpack (renderQuery True queryString)]
-        where http | secure = "https://"
-                   | otherwise = "http://"
-              isDefaultPort | secure    = port == 443
-                            | otherwise = port == 80
+    show (Req req) = concatMap B.unpack
+                         [ http, host req, portie, path req
+                         , renderQuery True $ queryString req ]
+        where http | secure req = "https://"
+                   | otherwise  = "http://"
+              isDefaultPort | secure req = port req == 443
+                            | otherwise  = port req == 80
               portie | isDefaultPort = ""
-                     | otherwise     = ":" ++ show port
+                     | otherwise     = B.pack $ ":" ++ show (port req)
 
 instance ToJSON Req where
-    toJSON req@(Req Request{..}) = toJSON [
-                                     "url" .= show req
-                                   , "method" .= method
-                                   , "headers" .= map (first CI.original)
-                                                  requestHeaders
+    toJSON req@(Req req') = toJSON [ "url"     .= show req
+                                   , "method"  .= method req'
+                                   , "headers" .= headers req'
                                    ]
+        where headers = map (first CI.original) . requestHeaders
 
 instance FromJSON Req where
     parseJSON (Object v) = do


### PR DESCRIPTION
This addresses the breakage reported in issue #5 by adapting the code in
question to the new API which doesn't expose the `Request` constructor
anymore. The code should work with the old and the new API and
therefore the build-dependancy doesn't need changing (although it
would be advisable to restrict the http-enumerator version to 0.7.*)
