### PR TITLE
Pronk doesn't build on OS/X

### DIFF
--- a/pronk.cabal
+++ b/pronk.cabal
@@ -49,7 +49,7 @@ library
   build-depends:
     aeson,
     base < 5,
-    bytestring,
+    bytestring >= 0.9.2.0,
     case-insensitive,
     criterion >= 0.6.0.0,
     deepseq,


### PR DESCRIPTION
``` bash
>uname -a
Darwin quark 11.2.0 Darwin Kernel Version 11.2.0: Tue Aug  9 20:54:00 PDT 2011; root:xnu-1699.24.8~1/RELEASE_X86_64 x86_64

> ghci --version
The Glorious Glasgow Haskell Compilation System, version 7.0.4

> cabal --version
cabal-install version 0.10.2
using version 1.10.2.0 of the Cabal library 

>  git lg -1
* h 9487197 t 0fff73f   (HEAD, origin/master, origin/HEAD, master) Make nicer with the reports. (10 days ago) <Bryan O'Sullivan> [2011-11-25 17:55:47 -0800] 

> cabal update
Downloading the latest package list from hackage.haskell.org
cabal update  7.43s user 0.38s system 23% cpu 33.792 total

> cabal configure && cabal install 
Resolving dependencies...
Configuring pronk-0.1.0...
Resolving dependencies...
Configuring pronk-0.1.0...
Preprocessing library pronk-0.1.0...
Preprocessing executables for pronk-0.1.0...
Building pronk-0.1.0...
Registering pronk-0.1.0...
[1 of 1] Compiling Main             ( app/App.hs, dist/build/pronk/pronk-tmp/Main.o )

app/App.hs:125:35: Not in scope: `BL.hPutStrLn'
cabal: Error: some packages failed to install:
pronk-0.1.0 failed during the building phase. The exception was:
ExitFailure 1
cabal install  7.23s user 0.38s system 98% cpu 7.701 total

```
